### PR TITLE
API for Entity (de)serialization

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ adventure = "4.12.0"
 kotlin = "1.7.22"
 hydrazine = "1.7.2"
 dependencyGetter = "v1.0.1"
-minestomData = "ddde11056e"
+minestomData = "df75eacd9d"
 hephaistos = "2.6.1"
 jetbrainsAnnotations = "23.0.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ adventure = "4.12.0"
 kotlin = "1.7.22"
 hydrazine = "1.7.2"
 dependencyGetter = "v1.0.1"
-minestomData = "df75eacd9d"
+minestomData = "ddde11056e"
 hephaistos = "2.6.1"
 jetbrainsAnnotations = "23.0.0"
 

--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.minestom.server.advancements.AdvancementManager;
 import net.minestom.server.adventure.bossbar.BossBarManager;
 import net.minestom.server.command.CommandManager;
+import net.minestom.server.entity.serialization.EntityProcessorManager;
 import net.minestom.server.event.GlobalEventHandler;
 import net.minestom.server.exception.ExceptionManager;
 import net.minestom.server.extensions.ExtensionManager;
@@ -187,6 +188,10 @@ public final class MinecraftServer {
 
     public static @NotNull PacketProcessor getPacketProcessor() {
         return serverProcess.packetProcessor();
+    }
+
+    public static @NotNull EntityProcessorManager getEntityProcessorManager() {
+        return serverProcess.entityProcessorManager();
     }
 
     public static boolean isStarted() {

--- a/src/main/java/net/minestom/server/ServerProcess.java
+++ b/src/main/java/net/minestom/server/ServerProcess.java
@@ -3,6 +3,7 @@ package net.minestom.server;
 import net.minestom.server.advancements.AdvancementManager;
 import net.minestom.server.adventure.bossbar.BossBarManager;
 import net.minestom.server.command.CommandManager;
+import net.minestom.server.entity.serialization.EntityProcessorManager;
 import net.minestom.server.event.GlobalEventHandler;
 import net.minestom.server.exception.ExceptionManager;
 import net.minestom.server.extensions.ExtensionManager;
@@ -123,6 +124,8 @@ public interface ServerProcess extends Snapshotable {
      */
     @NotNull PacketProcessor packetProcessor();
 
+    @NotNull EntityProcessorManager entityProcessorManager();
+
     /**
      * Exposed socket server.
      */
@@ -144,7 +147,7 @@ public interface ServerProcess extends Snapshotable {
 
     boolean isAlive();
 
-    @ApiStatus.NonExtendable
+  @ApiStatus.NonExtendable
     interface Ticker {
         void tick(long nanoTime);
     }

--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -5,6 +5,7 @@ import net.minestom.server.advancements.AdvancementManager;
 import net.minestom.server.adventure.bossbar.BossBarManager;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.serialization.EntityProcessorManager;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.GlobalEventHandler;
 import net.minestom.server.event.server.ServerTickMonitorEvent;
@@ -63,6 +64,7 @@ final class ServerProcessImpl implements ServerProcess {
     private final BiomeManager biome;
     private final AdvancementManager advancement;
     private final BossBarManager bossBar;
+    private final EntityProcessorManager entityProcessorManager;
     private final TagManager tag;
     private final Server server;
 
@@ -90,6 +92,7 @@ final class ServerProcessImpl implements ServerProcess {
         this.biome = new BiomeManager();
         this.advancement = new AdvancementManager();
         this.bossBar = new BossBarManager();
+        this.entityProcessorManager = new EntityProcessorManager();
         this.tag = new TagManager();
         this.server = new Server(packetProcessor);
 
@@ -185,6 +188,11 @@ final class ServerProcessImpl implements ServerProcess {
     @Override
     public @NotNull PacketProcessor packetProcessor() {
         return packetProcessor;
+    }
+
+    @Override
+    public @NotNull EntityProcessorManager entityProcessorManager() {
+        return entityProcessorManager;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -51,6 +51,7 @@ import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.timer.TaskSchedule;
 import net.minestom.server.utils.ArrayUtils;
+import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.async.AsyncUtils;
 import net.minestom.server.utils.block.BlockIterator;
@@ -178,6 +179,9 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     private long ticks;
 
     private final Acquirable<Entity> acquirable = Acquirable.of(this);
+
+    // Serialization related
+    private NamespaceID serializationKey;
 
     public Entity(@NotNull EntityType entityType, @NotNull UUID uuid) {
         this.id = generateId();
@@ -1719,6 +1723,14 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
                 .min(Comparator.comparingDouble(e -> e.getDistance(this.position)));
 
         return nearby.orElse(null);
+    }
+
+    public void setSerializationKey(@Nullable NamespaceID serializationKey) {
+        this.serializationKey = serializationKey;
+    }
+
+    public @Nullable NamespaceID serializationKey() {
+        return serializationKey;
     }
 
     public enum Pose {

--- a/src/main/java/net/minestom/server/entity/serialization/EntityFactory.java
+++ b/src/main/java/net/minestom/server/entity/serialization/EntityFactory.java
@@ -1,0 +1,32 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.instance.Chunk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+
+public interface EntityFactory extends EntityProcessor {
+
+    /**
+     * Create and configure a new {@link Entity} with the provided data during a Chunk loading.
+     *
+     * @param chunk The loaded Chunk
+     * @param entityData The data to parse
+     * @return a new Entity or null if the factory was failed silently.
+     */
+    @Nullable Entity createChunkEntity(@NotNull Chunk chunk, @NotNull NBTCompound entityData);
+
+    /**
+     * The difference with the {@link #createChunkEntity(Chunk, NBTCompound)} method is that this method
+     * will be called in a context where there is no chunk loading.
+     * This method is absolutely optional and was thought to provide a way to deserialize entities
+     * for third party uses and is not used by Minestom by default.
+     *
+     * @param entityData The data to parse
+     * @return a new Entity or null if the factory was failed silently.
+     */
+    default @Nullable Entity createEntity(@NotNull NBTCompound entityData) {
+        return null;
+    }
+}

--- a/src/main/java/net/minestom/server/entity/serialization/EntityProcessor.java
+++ b/src/main/java/net/minestom/server/entity/serialization/EntityProcessor.java
@@ -1,0 +1,17 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.Instance;
+
+/**
+ * Represents an object that process entity data. This object may be an {@link EntityFactory}
+ * or a {@link EntitySerializer}.
+ * These implementations were thought to have methods to use during a {@link net.minestom.server.instance.IChunkLoader#saveChunk(Chunk)}
+ * or a {@link net.minestom.server.instance.IChunkLoader#loadChunk(Instance, int, int)}, but also they can have optional methods
+ * exposed for context out of Chunk loading/saving and will never be used by Minestom.
+ * Both implementations can fail during the data processing, and they also can fail silently just returning a null value.
+ * Exception handling depends on the caller. Default, in {@link net.minestom.server.instance.AnvilLoader} if this processor fails with an
+ * exception during a Chunk loading/saving it will be handled via {@link net.minestom.server.exception.ExceptionManager#handleException(Throwable)}, and
+ * whether a processor fails silently or not, all remaining processing of the entity will be carried out in the same way.
+ */
+public interface EntityProcessor {}

--- a/src/main/java/net/minestom/server/entity/serialization/EntityProcessorExpansion.java
+++ b/src/main/java/net/minestom/server/entity/serialization/EntityProcessorExpansion.java
@@ -1,0 +1,10 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.utils.NamespaceID;
+import org.jetbrains.annotations.NotNull;
+
+public record EntityProcessorExpansion(
+        @NotNull NamespaceID key,
+        @NotNull EntityFactory factory,
+        @NotNull EntitySerializer serializer
+) {}

--- a/src/main/java/net/minestom/server/entity/serialization/EntityProcessorManager.java
+++ b/src/main/java/net/minestom/server/entity/serialization/EntityProcessorManager.java
@@ -1,0 +1,73 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.utils.NamespaceID;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ApiStatus.Experimental
+public class EntityProcessorManager {
+
+    private volatile @NotNull FallbackEntityProcessor fallbackEntityProcessor = FallbackEntityProcessor.FAIL;
+    private final Map<ProcessorKey, EntityProcessor> entityProcessors = new ConcurrentHashMap<>();
+
+    public @NotNull EntityProcessorManager registerProcessor(
+            @NotNull NamespaceID key, @NotNull EntityProcessor processor) throws IllegalArgumentException {
+        EntityProcessorType<?> type;
+
+        if (processor instanceof EntityFactory) {
+            type = EntityProcessorType.FACTORY;
+        } else if (processor instanceof EntitySerializer) {
+            type = EntityProcessorType.SERIALIZER;
+        } else {
+            throw new IllegalArgumentException("Invalid Entity Processor");
+        }
+
+        this.entityProcessors.put(new ProcessorKey(key, type), processor);
+        return this;
+    }
+
+    public <T extends EntityProcessor> @Nullable EntityProcessor removeProcessor(
+            @NotNull NamespaceID key, @NotNull EntityProcessorType<T> type) {
+        return this.entityProcessors.remove(new ProcessorKey(key, type));
+    }
+
+    public <T extends EntityProcessor> @Nullable T findProcessor(@NotNull NamespaceID key, @NotNull EntityProcessorType<T> type) {
+        return type.cast(entityProcessors.get(new ProcessorKey(key, type)));
+    }
+
+    public <T extends EntityProcessor> @NotNull Optional<T> findOptionalProcessor(@NotNull NamespaceID key, @NotNull EntityProcessorType<T> type) {
+        return Optional.ofNullable(findProcessor(key, type));
+    }
+
+    public @NotNull Map<ProcessorKey, EntityProcessor> registeredProcessors() {
+        return entityProcessors;
+    }
+
+    public @NotNull EntityProcessorManager setFallbackEntityProcessor(@NotNull FallbackEntityProcessor fallbackEntityProcessor) {
+        this.fallbackEntityProcessor = fallbackEntityProcessor;
+        return this;
+    }
+
+    public @NotNull FallbackEntityProcessor fallbackEntityProcessor() {
+        return fallbackEntityProcessor;
+    }
+
+    public record ProcessorKey(NamespaceID key, EntityProcessorType<?> type) {
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) return true;
+            if (object == null || getClass() != object.getClass()) return false;
+            ProcessorKey that = (ProcessorKey) object;
+            return Objects.equals(key, that.key) && Objects.equals(type, that.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, type);
+        }
+    }
+}

--- a/src/main/java/net/minestom/server/entity/serialization/EntityProcessorType.java
+++ b/src/main/java/net/minestom/server/entity/serialization/EntityProcessorType.java
@@ -1,0 +1,16 @@
+package net.minestom.server.entity.serialization;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class EntityProcessorType<T extends EntityProcessor> {
+
+    public static final EntityProcessorType<EntitySerializer> SERIALIZER = new EntityProcessorType<>();
+    public static final EntityProcessorType<EntityFactory> FACTORY = new EntityProcessorType<>();
+
+    private EntityProcessorType() {}
+
+    @SuppressWarnings("unchecked")
+    public @NotNull T cast(@NotNull EntityProcessor processor) {
+        return (T) processor;
+    }
+}

--- a/src/main/java/net/minestom/server/entity/serialization/EntitySerializer.java
+++ b/src/main/java/net/minestom/server/entity/serialization/EntitySerializer.java
@@ -1,0 +1,33 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.instance.Chunk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+
+public interface EntitySerializer extends EntityProcessor {
+
+    /**
+     * Serialize an entity during a Chunk saving and return a new {@link NBTCompound} that can be converted into an entity
+     * using a {@link EntityFactory}.
+     *
+     * @param chunk The saved Chunk
+     * @param entity The entity to serialize
+     * @return A new NBTCompound or null if the serializer was failed silently.
+     */
+    @Nullable NBTCompound serializeChunkEntity(@NotNull Chunk chunk, @NotNull Entity entity);
+
+    /**
+     * The difference with the {@link #serializeChunkEntity(Chunk, Entity)} is that this method
+     * will be called in a context where there is no chunk loading.
+     * This method is absolutely optional and was thought to provide a way to serialize entities
+     * for third party uses and is not used by Minestom by default.
+     *
+     * @param entity The entity to serialize
+     * @return A new NBTCompound or null if the serializer was failed silently.
+     */
+    default @Nullable NBTCompound serializeEntity(@NotNull Entity entity) {
+        return null;
+    }
+}

--- a/src/main/java/net/minestom/server/entity/serialization/FallbackEntityProcessor.java
+++ b/src/main/java/net/minestom/server/entity/serialization/FallbackEntityProcessor.java
@@ -1,0 +1,24 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.instance.Chunk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+
+/**
+ * A Fallback processor to be used if a {@link EntityProcessor} is missing during a Chunk loading/saving.
+ */
+public interface FallbackEntityProcessor extends EntityFactory, EntitySerializer {
+    FallbackEntityProcessor FAIL = new FallbackEntityProcessor() {
+        @Override
+        public @Nullable Entity createChunkEntity(@NotNull Chunk chunk, @NotNull NBTCompound entityData) {
+            return null;
+        }
+
+        @Override
+        public @Nullable NBTCompound serializeChunkEntity(@NotNull Chunk chunk, @NotNull Entity entity) {
+            return null;
+        }
+    };
+}

--- a/src/main/java/net/minestom/server/entity/serialization/SignedEntitySerialization.java
+++ b/src/main/java/net/minestom/server/entity/serialization/SignedEntitySerialization.java
@@ -1,0 +1,95 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.utils.NamespaceID;
+import org.jetbrains.annotations.NotNull;
+import org.jglrxavpok.hephaistos.nbt.NBT;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SignedEntitySerialization {
+
+    private SignedEntitySerialization() {}
+
+    public static final String ENTITY_SERIALIZATION_KEY = "SerializationKey";
+
+    public static @NotNull List<Entity> deserializeChunkEntities(@NotNull Chunk chunk, @NotNull List<NBTCompound> entitiesData) {
+        List<Entity> entities = new ArrayList<>();
+        EntityProcessorManager processorRegistry = MinecraftServer.getEntityProcessorManager();
+
+        for (NBTCompound someEntityData : entitiesData) {
+            EntityFactory factory = null;
+            String foundKey = someEntityData.getString(ENTITY_SERIALIZATION_KEY);
+            NamespaceID serializationKey = null;
+
+            if (foundKey != null) {
+                factory = processorRegistry.findProcessor(serializationKey = NamespaceID.from(foundKey), EntityProcessorType.FACTORY);
+            }
+
+            if (factory == null) factory = processorRegistry.fallbackEntityProcessor();
+
+            Entity entity;
+            try {
+                entity = factory.createChunkEntity(chunk, someEntityData);
+            } catch (Throwable throwable) {
+                MinecraftServer.getExceptionManager().handleException(throwable);
+                continue;
+            }
+
+            if (entity == null) continue;
+
+            entities.add(entity);
+
+            entity.setSerializationKey(serializationKey);
+            if (entity.getInstance() == null) {
+                entity.setInstance(chunk.getInstance()); // CompletableFuture#get() to wait for spawning?
+            }
+        }
+
+        return entities;
+    }
+
+    public static @NotNull List<NBTCompound> serializeChunkEntities(@NotNull Chunk chunk) {
+        EntityProcessorManager processorRegistry = MinecraftServer.getEntityProcessorManager();
+
+        Instance instance = chunk.getInstance();
+        List<NBTCompound> serializedEntities = new ArrayList<>();
+
+        for (Entity entity : instance.getChunkEntities(chunk)) {
+            NamespaceID serializationKey = entity.serializationKey();
+
+            EntitySerializer serializer = null;
+
+            if (serializationKey != null) {
+                serializer = processorRegistry.findProcessor(serializationKey, EntityProcessorType.SERIALIZER);
+            }
+
+            if (serializer == null) serializer = processorRegistry.fallbackEntityProcessor();
+
+            NBTCompound serialized;
+            try {
+                serialized = serializer.serializeChunkEntity(chunk, entity);
+            } catch (Throwable error) {
+                MinecraftServer.getExceptionManager().handleException(error);
+                continue;
+            }
+
+            if (serialized == null) continue;
+
+            if (serializationKey != null) {
+                serialized = serialized.toMutableCompound()
+                        .set(ENTITY_SERIALIZATION_KEY, NBT.String(serializationKey.asString()))
+                        .toCompound();
+            }
+
+            serializedEntities.add(serialized);
+        }
+
+        return serializedEntities;
+    }
+}

--- a/src/main/java/net/minestom/server/instance/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/AnvilLoader.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntIntImmutablePair;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.serialization.SignedEntitySerialization;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.utils.NamespaceID;
@@ -33,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class AnvilLoader implements IChunkLoader {
+
     private final static Logger LOGGER = LoggerFactory.getLogger(AnvilLoader.class);
     private static final Biome BIOME = Biome.PLAINS;
 
@@ -127,6 +129,9 @@ public class AnvilLoader implements IChunkLoader {
 
             // Block entities
             loadBlockEntities(chunk, chunkReader);
+
+            // Entities
+            SignedEntitySerialization.deserializeChunkEntities(chunk, chunkReader.getOldEntities().asListView());
         }
         synchronized (perRegionLoadedChunks) {
             int regionX = CoordinatesKt.chunkToRegion(chunkX);
@@ -432,6 +437,8 @@ public class AnvilLoader implements IChunkLoader {
 
         chunkWriter.setSectionsData(NBT.List(NBTType.TAG_Compound, sectionData));
         chunkWriter.setBlockEntityData(NBT.List(NBTType.TAG_Compound, blockEntities));
+
+        chunkWriter.setOldEntityData(NBT.List(NBTType.TAG_Compound, SignedEntitySerialization.serializeChunkEntities(chunk)));
     }
 
     /**

--- a/src/test/java/net/minestom/server/entity/serialization/EntitySerializationTest.java
+++ b/src/test/java/net/minestom/server/entity/serialization/EntitySerializationTest.java
@@ -1,0 +1,49 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.utils.NamespaceID;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static net.minestom.server.entity.serialization.SignedEntitySerialization.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EntitySerializationTest {
+
+    private static final Instance TEST_INSTANCE;
+
+    static {
+        MinecraftServer.init();
+
+        TEST_INSTANCE = MinecraftServer.getInstanceManager()
+                .createInstanceContainer();
+
+        EntityProcessorManager entityProcessorManager = MinecraftServer.getEntityProcessorManager();
+        NamespaceID key = NamespaceID.from("minestom:test");
+        entityProcessorManager.registerProcessor(key, new TestEntitySerializer())
+                .registerProcessor(key, new TestEntityFactory());
+    }
+
+    @Test
+    public void testSignedSerialization() throws Exception {
+        Pos pos = new Pos(10, 10, 10, 5.0f, 7.0f);
+
+        Entity entity = new Entity(EntityType.CREEPER);
+        entity.setSerializationKey(NamespaceID.from("minestom:test"));
+        entity.setInstance(TEST_INSTANCE, pos).get();
+
+        Chunk entityChunk = entity.getChunk();
+        NBTCompound serialized = serializeChunkEntities(entityChunk).get(0);
+
+        Entity deserialized = deserializeChunkEntities(entityChunk, Collections.singletonList(serialized)).get(0);
+
+        assertEquals(pos, deserialized.getPosition());
+  }
+}

--- a/src/test/java/net/minestom/server/entity/serialization/TestEntityFactory.java
+++ b/src/test/java/net/minestom/server/entity/serialization/TestEntityFactory.java
@@ -1,0 +1,33 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.instance.Chunk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+
+import java.util.concurrent.ExecutionException;
+
+public class TestEntityFactory implements EntityFactory {
+    @Override
+    public @Nullable Entity createChunkEntity(@NotNull Chunk chunk, @NotNull NBTCompound entityData) {
+        NBTCompound positionData = entityData.getCompound("position");
+
+        double x = positionData.getAsDouble("x");
+        double y = positionData.getAsDouble("y");
+        double z = positionData.getAsDouble("z");
+        float yaw = positionData.getAsFloat("yaw");
+        float pitch = positionData.getAsFloat("pitch");
+
+        Pos pos = new Pos(x, y, z, yaw, pitch);
+        Entity entity = new Entity(EntityType.CREEPER);
+        try {
+            entity.setInstance(chunk.getInstance(), pos).get();
+            return entity;
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/net/minestom/server/entity/serialization/TestEntitySerializer.java
+++ b/src/test/java/net/minestom/server/entity/serialization/TestEntitySerializer.java
@@ -1,0 +1,28 @@
+package net.minestom.server.entity.serialization;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.instance.Chunk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jglrxavpok.hephaistos.nbt.NBT;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+import org.jglrxavpok.hephaistos.nbt.mutable.MutableNBTCompound;
+
+public class TestEntitySerializer implements EntitySerializer {
+
+    @Override
+    public @Nullable NBTCompound serializeChunkEntity(@NotNull Chunk chunk, @NotNull Entity entity) {
+        MutableNBTCompound compound = new MutableNBTCompound();
+
+        Pos pos = entity.getPosition();
+        MutableNBTCompound positionCompound = new MutableNBTCompound()
+                .set("x", NBT.Double(pos.x()))
+                .set("y", NBT.Double(pos.x()))
+                .set("z", NBT.Double(pos.z()))
+                .set("yaw", NBT.Float(pos.yaw()))
+                .set("pitch", NBT.Float(pos.pitch()));
+
+        return compound.set("position", positionCompound.toCompound()).toCompound();
+    }
+}


### PR DESCRIPTION
I was bored and I decided to come up with a (de)serialization API to Minestom when loading and saving chunks.

This is work that can be done in a custom Chunk Loader implementation. But I thought it was much better if Minestom had a universal registry that contained the functions necessary to (de)serialize entities. That way, Chunk Loader implementations would access these functions so that you would not need to create a custom Chunk Loader implementation to add support for loading and saving entities. This is handled by the EntityProcessorManager, a manager that stores entity factories and serializers and has a global instance that is exposed within the ServerProcess.

On the other hand, I ran into the problem of how the Chunk Loader would know which function to use to save and load entities, since otherwise the idea in the previous point would be useless. So I thought it was convenient to add a NamespaceID field within the Entity class so that when it was serialized the Chunk Loader would know which serializer to use, and for the deserialization of the entity it is expected that that NamespaceID is stored within the data corresponding to the entity. In case this NamespaceID is absent in both serialization and deserialization, the EntityProcessorManager has a fallback entity processor for cases where a suitable entity processor cannot be found for a certain operation. For this idea I added the SignedEntitySerialization class.

Other aspects of the operation of entity processors are documented in their respective classes.

I also added this in the AnvilLoader